### PR TITLE
Adding csv support

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "should": "^8.2.1"
   },
   "dependencies": {
+    "csv-parse": "^4.0.1",
     "js-yaml": "^3.5.4",
     "lodash.defaults": "^4.0.1",
     "lodash.foreach": "^3.0.3"


### PR DESCRIPTION
I need to use csv format with your plugin, so this is a pull request adding CSV support.
As CSV require options, I did also add an option parameter.

```
"csvdata": {
    "src":"./path/to/test/file.csv",
    "options":{
        "delimiter": ",",
        "columns":true,
        "trim": true,
        "skip_empty_lines": true,
        "skip_lines_with_error":true
    }
}
```