### PR TITLE
Adding a new option to ignore missing files if necessary

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,10 @@ metalsmith
       // Add nested property from file to the `data.test2` namespace:
       test2: {
         src: './path/to/test/file.json',
-        property: 'propName'
+        property: 'propName',
+        options: {
+          ignoreMissingFile: true, //do not throw an error if the file is missing. Defaults to "false"
+        }
       },
 
       // Add a plain JS object to the `data.test3` namespace:

--- a/src/index.js
+++ b/src/index.js
@@ -44,17 +44,16 @@ function plugin (opts) {
   function parse (file, prop, options) {
     var ext = path.extname(file)
     var parser = parsers[ext]
-    var stat
     var data
 
     try {
-      stat = fs.statSync(file)
+      if (!fs.existsSync(file) && options.ignoreMissingFile) {
+        // file not exists but ignoreMissingFile options allows it
+        return false
+      }
 
       // File type must be supported
       if (parsers.hasOwnProperty(ext) === -1) throw new Error('unsupported file type "' + ext + '"')
-
-      // File must exist
-      if (!stat.isFile()) throw new Error('file "' + file + '" not found')
 
       if (ext === '.csv') {
         data = []


### PR DESCRIPTION
I need sometimes to allow the file to be missing but fs.statSync(file) throw an error before the following test "stat.isFile()" is done and then this portion of code is not working.
This pull request add an option ignoreMissingFile which then simply return a "false" value in this case.